### PR TITLE
Dynamic linking by default

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,13 +19,18 @@ jobs:
          - python
          - ruby
          - rust
-       triplet:
-         - x86_64-linux-gnu
-         - arm-linux-gnueabi
-         - arm-linux-gnueabihf
-         - aarch64-linux-gnu
-         - mipsel-linux-gnu
-         - powerpc64le-linux-gnu
+       target:
+         - { platform: linux-arm,   triplet: arm-linux-gnueabi }
+         - { platform: linux-arm64, triplet: aarch64-linux-gnu }
+         - { platform: linux-x64,   triplet: x86_64-linux-gnu }
+         # NOTE:
+         # Now that we depend in tree-sitter-cli to regenerate the pulled parser
+         # all these platform doesn't make any sense. They're simply unsupported
+         # in the releases of tree-sitter.
+         #  - arm-linux-gnueabihf
+         #  - aarch64-linux-gnu
+         #  - mipsel-linux-gnu
+         #  - powerpc64le-linux-gnu
          #
          # FIXME: tree-sitter has a known (by me) bug by now:
          #          ld: unknown option -soname
@@ -40,13 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build ${{ matrix.lang }} for ${{ matrix.triplet }}
+      - name: Build ${{ matrix.lang }} for ${{ matrix.target.platform }}
         run: |
-          docker run --rm -v $(pwd):/workdir -e CROSS_TRIPLE=${{ matrix.triplet }} multiarch/crossbuild  ./lang ${{ matrix.lang }}
-      - name: Build ${{ matrix.lang }} for macos
-        if: ${{ matrix.os == 'macos' }}
-        run: |
-          ./lang ${{ matrix.lang }}
+          docker run --rm -v $(pwd):/workdir -e CROSS_TRIPLE=${{ matrix.target.triplet }} -e PLATFORM=${{ matrix.target.platform }} multiarch/crossbuild  ./lang d ${{ matrix.lang }}
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
@@ -78,8 +79,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build ${{ matrix.lang }} for macos
+        env:
+          PLATFORM: "macos-x64"
         run: |
-          ./lang ${{ matrix.lang }}
+          ./lang d ${{ matrix.lang }}
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/lang
+++ b/lang
@@ -1,57 +1,93 @@
 #! /usr/bin/env sh
 
+# Usage:
+#
+# ./lang [s|d] parser1 parser2 …
+#
+# where:
+#   [s|d]              = one of `s` or `d` for static or dynamic compilation,
+#                        respectively
+#   parser1, parser2 … = the names of the parsers to built from
+#                        https://www.github.com/tree-sitter/tree-sitter-$parserX …
+
 set -e
 set -x
 
+# Define the platform-specific:
+#
+# 1. static and dynamic extentions
+# 2. the compilers
+
+static="a"
 case "$OSTYPE" in
   darwin*)
-      EXT=dylib
       CC=cc
       CXX=c++
+      dynamic="dylib"
       ;;
   *)
-      EXT=so
       CC=gcc
       CXX=g++
+      dynamic="so"
       ;;
 esac
+
+# Define:
+#
+# 1. the output extension
+# 2. the libtree-sitter extension to delete (to force a static or dynamic
+#    compilation)
+# 3. the parsers
+build=$1             # s = static | d = dynamic
+extout=$dynamic      # output is always a dynamic lib
+if [ "s" = $build ]
+then
+  extrem=$static 
+else
+  extrem=$dynamic
+fi
+shift
+parsers=$@ # the names of the parsers
 
 # ################################################ #
 #          Clone and Build tree-sitter             #
 # ################################################ #
-#
-# NOTE: we delete produced .{dylib, so} files because they just mess with static
-# building step
 
+tstag="0.20.8"
 TSS="$PWD/tree-sitter" # Tree Sitter Source
 
 if [ ! -d "$TSS" ]
 then
   git clone https://github.com/tree-sitter/tree-sitter
   cd tree-sitter
-  git checkout tags/v0.20.8
+  git checkout "tags/v$tstag"
   make
-  rm libtree-sitter."$EXT"* # keep .a to statically link the .so
-  file libtree-sitter.a
+  rm libtree-sitter*.$extrem* 
   cd ..
 fi
 
+# Get tree-sitter-cli
+
+if [ -n "$PLATFORM" ]
+then
+  arch=$(uname -m)
+  wget "https://github.com/tree-sitter/tree-sitter/releases/download/v$tstag/tree-sitter-$PLATFORM.gz"
+fi
 
 # ################################################ #
 #     Clone then Build Languages passed in args    #
 # ################################################ #
 
-for lang in "$@"
+for lang in "$parsers"
 do
 
   GET=tree-sitter-$lang
-  if [ -z "$CROSS_TRIPLE" ]
+  if [ -z "$PLATFORM" ]
   then
-    OUT="$PWD/lib/libtree-sitter-$lang.$EXT"
+    OUT="$PWD/lib/libtree-sitter-$lang.$extout"
   else
-    OUT="$PWD/lib/libtree-sitter-$lang-$CROSS_TRIPLE.$EXT"
+    OUT="$PWD/lib/libtree-sitter-$lang-$PLATFORM.$extout"
   fi
-
 
   mkdir -p "lib"
 
@@ -66,8 +102,7 @@ do
   cd $GET/src
   set +e
   rm *.o
-  rm *.$EXT
-  rm *.$EXT*
+  rm *.$extout*
   set -e
 
   LDFLAGS="-L$TSS -lstdc++ -ltree-sitter"


### PR DESCRIPTION
Produce parsers dynamically linked to tree-sitter by default.

But static building option is still available for whoever needs it.