### PR TITLE
Regen parsers before compilation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ jobs:
        lang:
          - bash
          - c
-         - cpp
+         # - cpp # FIXME: `lang` needs to handle things differently maybe because it won't generate for this
          - embedded-template
          - html
          - java

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,8 +20,8 @@ jobs:
          - ruby
          - rust
        target:
-         - { platform: linux-arm,   triplet: arm-linux-gnueabi }
-         - { platform: linux-arm64, triplet: aarch64-linux-gnu }
+         # - { platform: linux-arm,   triplet: arm-linux-gnueabi }
+         # - { platform: linux-arm64, triplet: aarch64-linux-gnu }
          - { platform: linux-x64,   triplet: x86_64-linux-gnu }
          # NOTE:
          # Now that we depend in tree-sitter-cli to regenerate the pulled parser
@@ -46,8 +46,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build ${{ matrix.lang }} for ${{ matrix.target.platform }}
+        env:
+          PLATFORM: ${{ matrix.target.platform }}
         run: |
-          docker run --rm -v $(pwd):/workdir -e CROSS_TRIPLE=${{ matrix.target.triplet }} -e PLATFORM=${{ matrix.target.platform }} multiarch/crossbuild  ./lang d ${{ matrix.lang }}
+          ./lang d ${{ matrix.lang }}
+          # docker run --rm -v $(pwd):/workdir -e CROSS_TRIPLE=${{ matrix.target.triplet }} -e PLATFORM=${{ matrix.target.platform }} multiarch/crossbuild  ./lang d ${{ matrix.lang }}
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/lang
+++ b/lang
@@ -70,8 +70,11 @@ fi
 
 if [ -n "$PLATFORM" ]
 then
-  arch=$(uname -m)
-  wget "https://github.com/tree-sitter/tree-sitter/releases/download/v$tstag/tree-sitter-$PLATFORM.gz"
+  cli="tree-sitter-$PLATFORM"
+  gz="$cli.gz"
+  wget "https://github.com/tree-sitter/tree-sitter/releases/download/v$tstag/$gz"
+  gunzip "$gz"
+  chmod +x "$cli"
 fi
 
 # ################################################ #
@@ -99,7 +102,11 @@ do
     cd ..
   fi
 
-  cd $GET/src
+  # Regenerate. See https://github.com/tree-sitter/tree-sitter/issues/2731
+  cd $GET
+  ../$cli generate
+  # clean
+  cd src
   set +e
   rm *.o
   rm *.$extout*


### PR DESCRIPTION
This might be a regression, in the sense that we're generating less parsers for less platforms.

But in fact it's an important fix because we now regenerate the parsers before compiling them, and as it stands,
tree-sitter have issues when compiling parsers generated with a tree-sitter-cli of a different version from runtime.

See this issue: https://github.com/tree-sitter/tree-sitter/issues/2731

In the future, I need to visit the cross-platform CI script from tree-sitter itself and try to import it.

See this: https://github.com/tree-sitter/tree-sitter/tree/master/.github/scripts